### PR TITLE
Improve performance of clock.stop method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/*.o
+src/*.so
+src/*.dll

--- a/inst/include/RcppClock.h
+++ b/inst/include/RcppClock.h
@@ -1,8 +1,5 @@
 #include <Rcpp.h>
 #include <chrono>
-#include <iostream>
-#include <sstream>
-#include <fstream>
 #include <string>
 #include <map>
 
@@ -16,54 +13,35 @@ namespace Rcpp
   class Clock
   {
   private:
-    std::vector<std::chrono::high_resolution_clock::time_point> tick_times;
-    std::vector<std::chrono::high_resolution_clock::time_point> tock_times;
-    std::vector<std::string> tick_names;
-    std::vector<std::string> tock_names;
     std::vector<double> timers;
-    std::vector<std::string> tickers;
+    size_t ticks, tocks = 0;
+    TimesMap tickmap, tockmap;
+    std::pair<std::string, int> key;
 
   public:
     // start a timer
     void tick(std::string name)
     {
-      tick_names.push_back(name);
-      tick_times.push_back(now());
+      key.first = name;
+      key.second = ticks;
+      tickmap.insert(
+          std::pair<std::pair<std::string, int>, std::chrono::high_resolution_clock::time_point>(key, now()));
+      ticks += 1;
     }
 
     // stop a timer
     void tock(std::string name)
     {
-      tock_names.push_back(name);
-      tock_times.push_back(now());
+      key.first = name;
+      key.second = tocks;
+      tockmap.insert(
+          std::pair<std::pair<std::string, int>, std::chrono::high_resolution_clock::time_point>(key, now()));
+      tocks += 1;
     }
 
     // calculate timer durations
     void stop(std::string var_name)
     {
-      std::pair<TimesMap::iterator, bool> insertTime;
-      std::pair<std::string, int> key;
-
-      /* Sort ticks and tocks by tick_name and tock_name */
-
-      TimesMap tickmap;
-      for (std::size_t i = 0; i < tick_names.size(); ++i)
-      {
-        key.first = tick_names[i];
-        key.second = i;
-        insertTime = tickmap.insert(
-            std::pair<std::pair<std::string, int>, std::chrono::high_resolution_clock::time_point>(key, tick_times[i]));
-      }
-
-      TimesMap tockmap;
-      for (std::size_t i = 0; i < tock_names.size(); ++i)
-      {
-        key.first = tock_names[i];
-        key.second = i;
-        insertTime = tockmap.insert(
-            std::pair<std::pair<std::string, int>, std::chrono::high_resolution_clock::time_point>(key, tock_times[i]));
-      }
-
       std::vector<std::string> keys;
       keys.reserve(tickmap.size());
       std::vector<std::chrono::high_resolution_clock::time_point> ticks;
@@ -83,10 +61,9 @@ namespace Rcpp
 
       for (std::size_t i = 0; i < ticks.size(); ++i)
       {
-        tickers.push_back(keys[i]);
         timers.push_back(duration(tocks[i] - ticks[i]));
       }
-      DataFrame df = DataFrame::create(Named("ticker") = tickers, Named("timer") = timers);
+      DataFrame df = DataFrame::create(Named("ticker") = keys, Named("timer") = timers);
       df.attr("class") = "RcppClock";
       Environment env = Environment::global_env();
       env[var_name] = df;

--- a/inst/include/RcppClock.h
+++ b/inst/include/RcppClock.h
@@ -1,11 +1,20 @@
 #include <Rcpp.h>
 #include <chrono>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <string>
+#include <map>
 
 #define duration(a) std::chrono::duration_cast<std::chrono::nanoseconds>(a).count()
 #define now() std::chrono::high_resolution_clock::now()
 
-namespace Rcpp {
-  class Clock {
+typedef std::map<std::pair<std::string, int>, std::chrono::high_resolution_clock::time_point> TimesMap;
+
+namespace Rcpp
+{
+  class Clock
+  {
   private:
     std::vector<std::chrono::high_resolution_clock::time_point> tick_times;
     std::vector<std::chrono::high_resolution_clock::time_point> tock_times;
@@ -16,29 +25,66 @@ namespace Rcpp {
 
   public:
     // start a timer
-    void tick(std::string name) {
+    void tick(std::string name)
+    {
       tick_names.push_back(name);
       tick_times.push_back(now());
     }
 
     // stop a timer
-    void tock(std::string name) {
+    void tock(std::string name)
+    {
       tock_names.push_back(name);
       tock_times.push_back(now());
     }
 
     // calculate timer durations
-    void stop(std::string var_name) {
-      for (unsigned int i = 0; i < tick_names.size(); ++i) {
-        for (unsigned int j = 0; j < tock_names.size(); ++j) {
-          if (tick_names[i] == tock_names[j]) {
-            timers.push_back(duration(tock_times[j] - tick_times[i]));
-            tickers.push_back(tick_names[i]);
-            tock_times.erase(tock_times.begin() + j);
-            tock_names.erase(tock_names.begin() + j);
-            break;
-          }
-        }
+    void stop(std::string var_name)
+    {
+      std::pair<TimesMap::iterator, bool> insertTime;
+      std::pair<std::string, int> key;
+
+      /* Sort ticks and tocks by tick_name and tock_name */
+
+      TimesMap tickmap;
+      for (std::size_t i = 0; i < tick_names.size(); ++i)
+      {
+        key.first = tick_names[i];
+        key.second = i;
+        insertTime = tickmap.insert(
+            std::pair<std::pair<std::string, int>, std::chrono::high_resolution_clock::time_point>(key, tick_times[i]));
+      }
+
+      TimesMap tockmap;
+      for (std::size_t i = 0; i < tock_names.size(); ++i)
+      {
+        key.first = tock_names[i];
+        key.second = i;
+        insertTime = tockmap.insert(
+            std::pair<std::pair<std::string, int>, std::chrono::high_resolution_clock::time_point>(key, tock_times[i]));
+      }
+
+      std::vector<std::string> keys;
+      keys.reserve(tickmap.size());
+      std::vector<std::chrono::high_resolution_clock::time_point> ticks;
+      ticks.reserve(tickmap.size());
+      for (auto kv : tickmap)
+      {
+        keys.push_back(kv.first.first);
+        ticks.push_back(kv.second);
+      }
+
+      std::vector<std::chrono::high_resolution_clock::time_point> tocks;
+      tocks.reserve(tockmap.size());
+      for (auto kv : tockmap)
+      {
+        tocks.push_back(kv.second);
+      }
+
+      for (std::size_t i = 0; i < ticks.size(); ++i)
+      {
+        tickers.push_back(keys[i]);
+        timers.push_back(duration(tocks[i] - ticks[i]));
       }
       DataFrame df = DataFrame::create(Named("ticker") = tickers, Named("timer") = timers);
       df.attr("class") = "RcppClock";


### PR DESCRIPTION
Fixes https://github.com/zdebruine/RcppClock/issues/1

This is still work in Progress. Some things left to do:

- [ ] Benchmarking old vs. new implementation
- [ ] Check if results are equivalent
- [ ] Evaluate which #includes we really need (some of them were only needed for development)

You can install easily using: `devtools::install_github("zdebruine/RcppClock#2")`